### PR TITLE
Moves to nock for integration testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,8 +194,7 @@
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-      "dev": true
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
     },
     "async-each": {
       "version": "1.0.1",
@@ -782,6 +781,11 @@
       "requires": {
         "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
       }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -4185,15 +4189,13 @@
     "mkdirp": {
       "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
       },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -4326,6 +4328,54 @@
           "requires": {
             "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
           }
+        }
+      }
+    },
+    "nock": {
+      "version": "9.0.22",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.22.tgz",
+      "integrity": "sha512-F5+Z5jhDourTtGIAEdqdtLhuAqO22Kg2rrvszgxwDPl8rMkw/pY0RJUHvFV/4bv1/oReZRAokMNGrUIQlKi/BQ==",
+      "requires": {
+        "chai": "3.5.0",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "lodash": "4.17.4",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "propagate": "0.4.0",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+      },
+      "dependencies": {
+        "chai": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "requires": {
+            "assertion-error": "1.0.2",
+            "deep-eql": "0.1.3",
+            "type-detect": "1.0.0"
+          }
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
         }
       }
     },
@@ -4946,6 +4996,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
+    },
+    "propagate": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE="
     },
     "proto-list": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "blanket": "^1.2.3",
     "express": "^4.15.4",
+    "nock": "^9.0.22",
     "node-env-file": "^0.1.7",
     "pg": "6.4.1",
     "raven": "^2.1.2",

--- a/tests/int/skills/boomtown.js
+++ b/tests/int/skills/boomtown.js
@@ -1,28 +1,28 @@
 
 const boomtown = require('../../../src/skills/boomtown')
 const directMessage = require('../../fixtures/direct_message')
-const { SlappHelper } = require('../helpers')
+const { NockSlappHelper } = require('../helpers')
 const { expect } = require('chai')
 
 describe('boomtown', () => {
   let slappHelper
   beforeEach(() => {
-    slappHelper = new SlappHelper(boomtown)
+    slappHelper = new NockSlappHelper(boomtown)
   })
 
   describe('with correct value', () => {
     it('should reply then die', async () => {
       let directMessageCopy = JSON.parse(JSON.stringify(directMessage))
       directMessageCopy.event.text = 'boomtown ' + process.env.DEV_BOOMTOWN
-      let msgSpy
+      let matcher = (body) => {
+        expect(body.text).to.eql('About to die...')
+        return true
+      }
       try {
-        msgSpy = await slappHelper.sendEvent(directMessageCopy)
+        await slappHelper.sendEvent(directMessageCopy, matcher)
       } catch (e) {
         expect(e).to.be.an('error')
       }
-      expect(msgSpy.callCount).to.eql(1)
-      let callArgs = msgSpy.getCall(0)
-      expect(callArgs.args[0].text).to.include('About to die...')
     })
   })
 
@@ -30,8 +30,10 @@ describe('boomtown', () => {
     it('should not respond', async () => {
       let directMessageCopy = JSON.parse(JSON.stringify(directMessage))
       directMessageCopy.event.text = 'boomtown abcdef'
-      let msgSpy = await slappHelper.sendEvent(directMessageCopy)
-      expect(msgSpy.callCount).to.eql(0)
+      let matcher = (body) => {
+        throw Error('Should not send request')
+      }
+      await slappHelper.sendEvent(directMessageCopy, matcher)
     })
   })
 })

--- a/tests/int/skills/echo.js
+++ b/tests/int/skills/echo.js
@@ -1,20 +1,21 @@
 const echo = require('../../../src/skills/echo')
 const directMessage = require('../../fixtures/direct_message')
-const { SlappHelper } = require('../helpers')
+const { NockSlappHelper } = require('../helpers')
 const { expect } = require('chai')
 
 describe('echo', () => {
   let slappHelper
   beforeEach(() => {
-    slappHelper = new SlappHelper(echo)
+    slappHelper = new NockSlappHelper(echo)
   })
 
   describe('without text to echo', () => {
     it('should respond with help text', async () => {
-      let msgSpy = await slappHelper.sendEvent(directMessage)
-      expect(msgSpy.callCount).to.eql(1)
-      let callArgs = msgSpy.getCall(0)
-      expect(callArgs.args[0].text).to.include('Looks like you would')
+      let matcher = (body) => {
+        expect(body.text).to.include('Looks like you would')
+        return true
+      }
+      await slappHelper.sendEvent(directMessage, matcher)
     })
   })
 
@@ -22,10 +23,11 @@ describe('echo', () => {
     it('should with echo text', async () => {
       let directMessageCopy = JSON.parse(JSON.stringify(directMessage))
       directMessageCopy.event.text = 'echo hello world'
-      let msgSpy = await slappHelper.sendEvent(directMessageCopy)
-      expect(msgSpy.callCount).to.eql(1)
-      let callArgs = msgSpy.getCall(0)
-      expect(callArgs.args[0].text).to.eql('echo hello world')
+      let matcher = (body) => {
+        expect(body.text).to.eql('echo hello world')
+        return true
+      }
+      await slappHelper.sendEvent(directMessage, matcher)
     })
   })
 })


### PR DESCRIPTION
We've had some issues using spies to spy on `msg.say` or `slack.chat.postMessage` so this migrates the tests to use nock and mock at the http client level